### PR TITLE
Put a border over the polygon

### DIFF
--- a/HexamauiAppSample/HexagonBorder.cs
+++ b/HexamauiAppSample/HexagonBorder.cs
@@ -119,15 +119,11 @@ namespace HexamauiAppSample
             AbsoluteLayout absoluteLayout = new AbsoluteLayout();
             absoluteLayout.VerticalOptions = LayoutOptions.Center;
             absoluteLayout.HorizontalOptions = LayoutOptions.Center;
-            absoluteLayout.MaximumHeightRequest = 1000;
-            absoluteLayout.MaximumWidthRequest = 1000;
             Point center = new(absoluteLayout.X, absoluteLayout.Y);
-            Point size = new Point(60, 60);
-            HexagonLayout hexLayout = new HexagonLayout(Orientation.PointyLayout, size, center);
-            List<Hex> hexes = new List<Hex>(5);
-            hexes = HexagonalGridShapes.GetMapShapes(hexes, GridOrientationConsts.PointyOrientation, HexagonalGridShapes.Hexagon);
-
-
+            Point size = new Point(60.0, 60.0);
+            HexagonLayout hexLayout = new HexagonLayout(Orientation.FlatLayout, size, center);
+            List<Hex> hexes = new List<Hex>(7);
+            hexes = HexagonalGridShapes.GetMapShapes(hexes, GridOrientationConsts.FlatOrientation, HexagonalGridShapes.Hexagon);
 
             hexes.ForEach(hex =>
             {
@@ -135,28 +131,30 @@ namespace HexamauiAppSample
                 Point[] pointsArray = Hexagon.HexagonPolygonCorners(hexLayout, hex).ToArray();
                 PointCollection points = new PointCollection(pointsArray);
                 Point pixels = hexLayout.HexToPixel(hex);
+
+                double height = Orientation.PointyLayout == hexLayout.HexOrientation ? 2 * size.Y : Math.Sqrt(3) * size.Y;
+                double width = Orientation.PointyLayout == hexLayout.HexOrientation ? Math.Sqrt(3) * size.X : 2 * size.X;
+                double strokeThickness = 3;
+
                 Polygon currentHex = new Polygon
                 {
-                    Frame = new(pixels.X, pixels.Y, size.X, size.Y),
                     Points = points,
                     Fill = Color.FromArgb("#2B0B98"),
                     Stroke = Color.FromArgb("#C49B33"),
                     Aspect = Stretch.Fill,
-                    StrokeThickness = 5,
-                    TranslationX = pixels.X,
-                    TranslationY = pixels.Y,
+                    //StrokeThickness = 2,
                 };
                 Border border = new Border
                 {
                     Stroke = currentHex.Stroke,
                     Padding = 0,
                     Background = currentHex.Fill,
-                    StrokeThickness = currentHex.StrokeThickness,
-                    TranslationX = currentHex.TranslationX,
-                    TranslationY = currentHex.TranslationY,
+                    StrokeThickness = strokeThickness,
+                    TranslationX = pixels.X,
+                    TranslationY = pixels.Y,
+                    HeightRequest = height - strokeThickness,
+                    WidthRequest = width - strokeThickness,
                     StrokeShape = currentHex,
-                    HeightRequest = size.Y,
-                    WidthRequest = size.X,
                 };
                 
                 //Tap Gesture Set-Up

--- a/HexamauiAppSample/HexagonBorder.cs
+++ b/HexamauiAppSample/HexagonBorder.cs
@@ -142,29 +142,40 @@ namespace HexamauiAppSample
                     Fill = Color.FromArgb("#2B0B98"),
                     Stroke = Color.FromArgb("#C49B33"),
                     Aspect = Stretch.Fill,
-                    StrokeThickness = 2,
-                    //HeightRequest = size.Y,
-                    //WidthRequest = size.X,
+                    StrokeThickness = 5,
                     TranslationX = pixels.X,
                     TranslationY = pixels.Y,
                 };
-
+                Border border = new Border
+                {
+                    Stroke = currentHex.Stroke,
+                    Padding = 0,
+                    Background = currentHex.Fill,
+                    StrokeThickness = currentHex.StrokeThickness,
+                    TranslationX = currentHex.TranslationX,
+                    TranslationY = currentHex.TranslationY,
+                    StrokeShape = currentHex,
+                    HeightRequest = size.Y,
+                    WidthRequest = size.X,
+                };
+                
                 //Tap Gesture Set-Up
                 TapGestureRecognizer HexagonTapGestureRecognizer = new TapGestureRecognizer
                 {
                     Buttons = ButtonsMask.Primary,
                 };
                 HexagonTapGestureRecognizer.Tapped += (s, e) => OnHexagonPrimaryTapped(s!, e); 
+                
                 TapGestureRecognizer HexagonSecondaryTapGestureRecognizer = new TapGestureRecognizer
                 {
                     Buttons = ButtonsMask.Secondary,
                 };
                 HexagonSecondaryTapGestureRecognizer.Tapped += (s, e) => OnHexagonSecondaryTapped(s!, e);
 
-                currentHex.GestureRecognizers.Add(HexagonTapGestureRecognizer);
-                currentHex.GestureRecognizers.Add(HexagonSecondaryTapGestureRecognizer);
+                border.GestureRecognizers.Add(HexagonTapGestureRecognizer);
+                border.GestureRecognizers.Add(HexagonSecondaryTapGestureRecognizer);
 
-                absoluteLayout.Children.Add(currentHex);
+                absoluteLayout.Children.Add(border);
             });
             AbsoluteLayoutVar = absoluteLayout;
         }
@@ -172,14 +183,14 @@ namespace HexamauiAppSample
         //following https://learn.microsoft.com/en-us/dotnet/maui/fundamentals/gestures/tap?view=net-maui-8.0#define-the-button-mask
         public void OnHexagonPrimaryTapped(object sender, TappedEventArgs e)
         {
-            Polygon hex = (Polygon)sender;
-            hex.Fill = Colors.LimeGreen;
+            Border hex = (Border)sender;
+            hex.Background = Colors.LimeGreen;
         }
 
         public void OnHexagonSecondaryTapped(object sender, TappedEventArgs e)
         {
-            Polygon hex = (Polygon)sender;
-            hex.Fill = Colors.Red;
+            Border hex = (Border)sender;
+            hex.Background = Colors.Red;
         }
 
 


### PR DESCRIPTION
For the UI, the way I draw my hexagons in abundance is by using an AbsoluteLayout with Polygons in it. It looks decent enough: 
![image](https://github.com/DianaSoltani/Hexamaui/assets/31975705/642f9f4d-27aa-4d5a-89f9-6360ec64d45e)

 
Turns out, this is not enough since I want to able to display content within my beautiful hexagons (like labels, for example). After some discussions, it turns out I need a Border. By creating the border, I was able to fix a tap gesture recognizer problem on the polygon where if i click outside the actual hexagon but within the frame of the hexagon, it would register a click on that element valid.
![image](https://github.com/DianaSoltani/Hexamaui/assets/31975705/a076bef9-3a95-4ba4-9330-3eaa1521e024)

 
It works almost perfectly except for that I cant seem to be able to set the aspect for the border the same way that i do with the polygon by setting Aspect = Stretch.Fill.
 
![image](https://github.com/DianaSoltani/Hexamaui/assets/31975705/5e2b8dce-a326-4a45-807c-d6ec60de8db1)

 
The closest I've been able to get is by setting Scale to `2.0` and it looks so wonky and feels wrong. Setting Horizontal/VerticalOptions to fill also don't work in this case.
![image](https://github.com/DianaSoltani/Hexamaui/assets/31975705/6804ff10-ac46-4562-a221-59ba8da27e72)

It turns out I forgot to calculate for the correct size of the actual Hexagon!! Putting a hexagon to fit the top and bottom with left and right to the borders of a square actually makes a non regular hexagon - a slightly wider or slightly taller hexagon. To correctly determine the true Width and the true Height, again based on orientations, the right calculation is:
Pointy top height = 2*y
pointy top width = sqrt(3) * x
flat top height = sqrt(3)*y
flat top width = 2*x 
![image](https://github.com/DianaSoltani/Hexamaui/assets/31975705/5d538ca5-906f-49b7-bb20-7c4522e9f3f8)
